### PR TITLE
Handle AllSellersGone

### DIFF
--- a/sources/include/extension/Alert.hpp
+++ b/sources/include/extension/Alert.hpp
@@ -548,6 +548,19 @@ namespace alert {
         const Coin::KeyPair contractKeyPair;
         const Coin::PubKeyHash finalPkHash;
     };
+
+    struct AllSellersGone : public libtorrent::torrent_alert {
+
+        AllSellersGone(libtorrent::aux::stack_allocator& alloc,
+                       const libtorrent::torrent_handle & h)
+            : libtorrent::torrent_alert(alloc, h) {}
+
+        TORRENT_DEFINE_ALERT(DownloadStarted, libtorrent::user_alert_id + 32)
+        static const int static_category = alert::status_notification;
+        virtual std::string message() const override {
+            return torrent_alert::message() + " all sellers gone";
+        }
+    };
 }
 }
 }

--- a/sources/include/extension/TorrentPlugin.hpp
+++ b/sources/include/extension/TorrentPlugin.hpp
@@ -215,6 +215,7 @@ private:
     protocol_session::AnchorAnnounced<libtorrent::peer_id> anchorAnnounced();
     protocol_session::ReceivedValidPayment<libtorrent::peer_id> receivedValidPayment();
     protocol_session::SentPayment<libtorrent::peer_id> sentPayment();
+    protocol_session::AllSellersGone allSellersGone();
 
     /// Members
 

--- a/sources/src/TorrentPlugin.cpp
+++ b/sources/src/TorrentPlugin.cpp
@@ -466,7 +466,8 @@ void TorrentPlugin::toBuyMode(const protocol_wire::BuyerTerms & terms) {
                        fullPieceArrived(),
                        sentPayment(),
                        terms,
-                       torrentPieceInformation());
+                       torrentPieceInformation(),
+                       allSellersGone());
 
     // Send notification
     _alertManager->emplace_alert<alert::SessionToBuyMode>(_torrent, terms);
@@ -856,6 +857,17 @@ protocol_session::SentPayment<libtorrent::peer_id> TorrentPlugin::sentPayment() 
         manager.emplace_alert<alert::SentPayment>(h, endPoint, peerId, paymentIncrement, totalNumberOfPayments, totalAmountPaid, pieceIndex);
     };
 
+}
+
+protocol_session::AllSellersGone TorrentPlugin::allSellersGone() {
+  // Get alert manager and handle for torrent
+  libtorrent::torrent * t = torrent();
+  libtorrent::alert_manager & manager = t->alerts();
+  libtorrent::torrent_handle h = t->get_handle();
+
+  return [&manager, h, this](void) -> void {
+    manager.emplace_alert<alert::AllSellersGone>(h);
+  };
 }
 
 int TorrentPlugin::pickNextPiece(const std::vector<protocol_session::detail::Piece<libtorrent::peer_id>> * pieces) {


### PR DESCRIPTION
Add a AllSellersGone callback handler, and corresponding event to be emitted.

Depends on https://github.com/JoyStream/protocol_session-cpp/pull/26